### PR TITLE
Fix melt composition calculation bug

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,5 @@
-from importlib import metadata
-__version__ = metadata.version("Sulfur_X")
+from importlib.metadata import version, PackageNotFoundError
+try:
+    __version__ = version("Sulfur_X")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+from importlib import metadata
+__version__ = metadata.version("Sulfur_X")

--- a/melt_composition.py
+++ b/melt_composition.py
@@ -12,32 +12,23 @@ class MeltComposition:
     def __init__(self, melt_fraction, choice):
 
         if choice == 1:# Input melt composition change as a function of k2O here if crystallization is enabled.
-             if melt_fraction > 0.16:
-                k2o = 0.5 / melt_fraction
-                sio2 = 0.7993 * k2o ** 2 + 1.3594 * k2o + 47.724
-                al2o3 = 0.1359 * k2o ** 2 -1.7216 * k2o+ 19.556
-                feot = -0.2452 * k2o + 8.3786
-                mgo = -0.4446 * k2o ** 2 + 1.1916 * k2o+ 4.2932
-                cao = 0.3869 * k2o ** 2 - 4.5494 * k2o + 15.852
-                na2o = 0.2359 * k2o ** 2 - 0.2212 * k2o + 3.4682
-                p2o5 = -0.0438 * k2o ** 2 + 0.2943 * k2o + 0.5277
-                mno = 0.14
-                tio2 = 3
-             else:
+            if melt_fraction > 0.16:
+                pass
+            else:
                 melt_fraction = 0.16
-                k2o = 0.5 / melt_fraction
-                sio2 = 0.7993 * k2o ** 2 + 1.3594 * k2o + 47.724
-                al2o3 = 0.1359 * k2o ** 2 - 1.7216 * k2o + 19.556
-                feot = -0.2452 * k2o + 8.3786
-                mgo = -0.4446 * k2o ** 2 + 1.1916 * k2o + 4.2932
-                cao = 0.3869 * k2o ** 2 - 4.5494 * melt_fraction + 15.852
-                na2o = 0.2359 * k2o ** 2 - 0.2212 * k2o + 3.4682
-                p2o5 = -0.0438 * k2o ** 2 + 0.2943 * k2o + 0.5277
-                mno = 0.14
-                tio2 = 3
+                
+            k2o = 0.5 / melt_fraction
+            sio2 = 0.7993 * k2o ** 2 + 1.3594 * k2o + 47.724
+            al2o3 = 0.1359 * k2o ** 2 - 1.7216 * k2o + 19.556
+            feot = -0.2452 * k2o + 8.3786
+            mgo = -0.4446 * k2o ** 2 + 1.1916 * k2o + 4.2932
+            cao = 0.3869 * k2o ** 2 - 4.5494 * k2o + 15.852
+            na2o = 0.2359 * k2o ** 2 - 0.2212 * k2o + 3.4682
+            p2o5 = -0.0438 * k2o ** 2 + 0.2943 * k2o + 0.5277
+            mno = 0.14
+            tio2 = 3
             
         else: # Input melt composition here if crystallization is disabled.
-            
             sio2 = 51.46/ melt_fraction
             al2o3 = 17.43 / melt_fraction
             feot = 9.42 / melt_fraction
@@ -47,29 +38,24 @@ class MeltComposition:
             k2o = 0.78 / melt_fraction
             p2o5 = 0.24 / melt_fraction
             mno = 0.19 / melt_fraction
-            tio2 = 1.06 / melt_fraction
+            tio2 = 1.06 / melt_fraction          
 
+        new_composition = {
+            "SiO2": sio2,
+            "Al2O3": al2o3,
+            "TiO2": tio2,
+            "FeOT": feot,
+            "MgO": mgo,
+            "CaO": cao,
+            "Na2O": na2o,
+            "K2O": k2o,
+            "P2O5": p2o5,
+            "MnO": mno,
+        }
+        comp_sum = sum(new_composition.values())
+        
+        new_composition_normed = {
+            k: v*100/comp_sum for k, v in new_composition.items()
+        }
 
-            
-
-        sio2_n = 100 * sio2 / (sio2 + al2o3 + feot + mgo + cao + na2o + k2o + p2o5 + mno + tio2)
-        al2o3_n = 100 * al2o3 / (sio2 + al2o3 + feot + mgo + cao + na2o + k2o + p2o5 + mno + tio2)
-        feot_n = 100 * feot / (sio2 + al2o3 + feot + mgo + cao + na2o + k2o + p2o5 + mno + tio2)
-        mgo_n = 100 * mgo / (sio2 + al2o3 + feot + mgo + cao + na2o + k2o + p2o5 + mno + tio2)
-        cao_n = 100 * cao / (sio2 + al2o3 + feot + mgo + cao + na2o + k2o + p2o5 + mno + tio2)
-        na2o_n = 100 * na2o / (sio2 + al2o3 + feot + mgo + cao + na2o + k2o + p2o5 + mno + tio2)
-        k2o_n = 100 * k2o / (sio2 + al2o3 + feot + mgo + cao + na2o + k2o + p2o5 + mno + tio2)
-        p2o5_n = 100 * p2o5 / (sio2 + al2o3 + feot + mgo + cao + na2o + k2o + p2o5 + mno + tio2)
-        mno_n = 100 * mno / (sio2 + al2o3 + feot + mgo + cao + na2o + k2o + p2o5 + mno + tio2)
-        tio2_n = 100 * tio2 / (sio2 + al2o3 + feot + mgo + cao + na2o + k2o + p2o5 + mno + tio2)
-        self.composition = {"SiO2": sio2_n,
-                            "Al2O3": al2o3_n,
-                            "TiO2": tio2_n,
-                            "FeOT": feot_n,
-                            "MgO": mgo_n,
-                            "CaO": cao_n,
-                            "Na2O": na2o_n,
-                            "K2O": k2o_n,
-                            "P2O5": p2o5_n,
-                            "MnO": mno_n,
-                            }
+        self.composition = new_composition_normed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "Sulfur_X"
+version = "1.2.1"
+readme = "README.md"
+authors = [{name = "Shuo Ding"}]
+dependencies = [
+    "numpy",
+    "pandas",
+    "matplotlib",
+    "scipy.optimize",
+    "scipy.stats",
+    "tqdm",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "numpy",
     "pandas",
     "matplotlib",
-    "scipy.optimize",
-    "scipy.stats",
+    "scipy",
     "tqdm",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,12 @@ dependencies = [
     "scipy",
     "tqdm",
 ]
+
+[tool.setuptools]
+py-modules = [
+    "Iacono_Marziano_COH", "SCSS_model", "S_Fe", "VC_COH",
+    "degassingrun", "fuegodegassing", "fugacity", "main_Fuego",
+    "melt_composition", "newvariables", "oxygen_fugacity",
+    "s_isotope", "sulfur_fO2_degassing_test",
+    "sulfur_partition_coefficients",
+]


### PR DESCRIPTION
The MeltComposition class had a repeated if/else depending on melt_fraction (>0.16 or not). The calculation in the else block had a typo where melt_fraction was written instead of k2o when calculating cao. To avoid copy-paste typos, I collapsed this into one statement. I also tidied up the code just after it for the same reason.

I added a pyproject.toml file and an __init__.py file so that users can track which version they are running by doing:

```python
import Sulfur_X
print(Sulfur_X.__version__)
```